### PR TITLE
Fix CircleCI config

### DIFF
--- a/{{ cookiecutter.repo_name }}/.circleci/config.yml
+++ b/{{ cookiecutter.repo_name }}/.circleci/config.yml
@@ -157,7 +157,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - develop:
           requires:
             - test


### PR DESCRIPTION
Fixes an issue where git tag builds will not run without setting this filter