### PR TITLE
Clean up use case implementation

### DIFF
--- a/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/BaseUseCase.kt
+++ b/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/BaseUseCase.kt
@@ -1,0 +1,11 @@
+package {{ cookiecutter.package_name }}.domain.interactor
+
+abstract class BaseUseCase<in T, out R> {
+    operator fun invoke(params: T): R {
+        return execute(params)
+    }
+
+    protected abstract fun execute(params: T): R
+}
+
+operator fun <R> BaseUseCase<Unit, R>.invoke(): R = this(Unit)

--- a/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/CompletableUseCase.kt
+++ b/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/CompletableUseCase.kt
@@ -2,4 +2,4 @@ package {{ cookiecutter.package_name }}.domain.interactor
 
 import io.reactivex.Completable
 
-abstract class CompletableUseCase<in T> : UseCase<T, Completable>
+abstract class CompletableUseCase<in T> : BaseUseCase<T, Completable>()

--- a/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/FlowableUseCase.kt
+++ b/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/FlowableUseCase.kt
@@ -2,4 +2,4 @@ package {{ cookiecutter.package_name }}.domain.interactor
 
 import io.reactivex.Flowable
 
-abstract class FlowableUseCase<in T, R> : UseCase<T, Flowable<R>>
+abstract class FlowableUseCase<in T, R> : BaseUseCase<T, Flowable<R>>()

--- a/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/MaybeUseCase.kt
+++ b/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/MaybeUseCase.kt
@@ -2,4 +2,4 @@ package {{ cookiecutter.package_name }}.domain.interactor
 
 import io.reactivex.Maybe
 
-abstract class MaybeUseCase<in T, R> : UseCase<T, Maybe<R>>
+abstract class MaybeUseCase<in T, R> : BaseUseCase<T, Maybe<R>>()

--- a/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/ObservableUseCase.kt
+++ b/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/ObservableUseCase.kt
@@ -2,4 +2,4 @@ package {{ cookiecutter.package_name }}.domain.interactor
 
 import io.reactivex.Observable
 
-abstract class ObservableUseCase<in T, R> : UseCase<T, Observable<R>>
+abstract class ObservableUseCase<in T, R> : BaseUseCase<T, Observable<R>>()

--- a/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/SingleUseCase.kt
+++ b/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/SingleUseCase.kt
@@ -2,4 +2,4 @@ package {{ cookiecutter.package_name }}.domain.interactor
 
 import io.reactivex.Single
 
-abstract class SingleUseCase<in T, R> : UseCase<T, Single<R>>
+abstract class SingleUseCase<in T, R> : BaseUseCase<T, Single<R>>()

--- a/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/UseCase.kt
+++ b/{{ cookiecutter.repo_name }}/domain/src/main/java/{{ cookiecutter.package_dir }}/domain/interactor/UseCase.kt
@@ -1,5 +1,0 @@
-package {{ cookiecutter.package_name }}.domain.interactor
-
-interface UseCase<in T, out R> {
-    fun execute(params: T? = null): R
-}


### PR DESCRIPTION
The previous iteration of use cases could cleanly account for non-null or non-existent parameters. We would be would have to force unwrap the parameters to be able to use them inside of the use case without compiler warnings.

This implementation also allows for code like this:
```
getUser.execute(userId).subscribe()
```
to be replaced with code like this:
```
getUser(userId).subscribe()
```