### PR TITLE
Add dependency checks

### DIFF
--- a/{{ cookiecutter.repo_name }}/.circleci/config.yml
+++ b/{{ cookiecutter.repo_name }}/.circleci/config.yml
@@ -545,10 +545,44 @@ jobs:
       - store_artifacts:
           <<: *apk_artifacts
 
+  dependency_checks:
+    <<: *defaults
+    steps:
+      - run:
+        <<: *update_sdk
+
+      - checkout
+
+      - restore_cache:
+          <<: *cache_key
+
+      - run: bundle install
+
+      - run:
+          <<: *download_dependencies
+
+      - run:
+          name: Check project dependency versions
+          command: ./gradlew dependencyUpdates --no-daemon
+
+      - run:
+          name: Run Danger for dependency version checks
+          command: bundle exec danger --dangerfile=Dangerfile-dependencies --fail-on-errors=true
+
+      - save_cache:
+          <<: *cache_key
+          paths:
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
+
 workflows:
   version: 2
   build_and_test:
     jobs:
+      - dependency_checks:
+          filters:
+            tags:
+              only: /.*/
       - lint_develop:
           filters:
             tags:
@@ -602,6 +636,7 @@ workflows:
             - checkstyle_develop
             - lint_develop
             - test_develop
+            - dependency_checks
           filters:
             branches:
               only: develop

--- a/{{ cookiecutter.repo_name }}/Dangerfile-dependencies
+++ b/{{ cookiecutter.repo_name }}/Dangerfile-dependencies
@@ -1,0 +1,5 @@
+fileContent = File.open("./build/dependencyUpdates/report.txt", "rb").read
+toRemove = "The following dependencies have later milestone versions:”
+contentToPrint = fileContent.slice(fileContent.index(toRemove)..-1)
+
+warn(contentToPrint)

--- a/{{ cookiecutter.repo_name }}/build.gradle
+++ b/{{ cookiecutter.repo_name }}/build.gradle
@@ -3,6 +3,7 @@ import com.android.build.gradle.FeaturePlugin
 import com.android.build.gradle.LibraryPlugin
 
 apply from: "${project.rootDir}/gradle/dependencies.gradle"
+apply plugin: "com.github.ben-manes.versions"
 
 allprojects {
     repositories {
@@ -93,6 +94,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'de.felixschulze.gradle:gradle-hockeyapp-plugin:3.6'
         classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:5.1.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.20.0"
     }
     
     configurations.all {


### PR DESCRIPTION
Due to how the Gradle dependencies are declared we no longer have the benefit of Android Studio giving us a lint warning when the dependency is out of date. This adds a Danger bot check to update any dependencies that get out of date. The Danger bot will leave a comment directly on a PR.