### PR TITLE
Lint rules

### DIFF
--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/DefaultLayoutAttributeDetector.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/DefaultLayoutAttributeDetector.kt
@@ -1,0 +1,39 @@
+package {{ cookiecutter.package_name }}.lint
+
+import com.android.SdkConstants.ATTR_TEXT_STYLE
+import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.LayoutDetector
+import com.android.tools.lint.detector.api.Scope.Companion.RESOURCE_FILE_SCOPE
+import com.android.tools.lint.detector.api.Severity.WARNING
+import com.android.tools.lint.detector.api.XmlContext
+import org.w3c.dom.Attr
+
+private const val PRIORITY = 2
+
+val ISSUE_DEFAULT_LAYOUT_ATTRIBUTE = Issue.create("DefaultLayoutAttribute",
+        "Default layout value",
+        "Flags default layout values that are not needed." +
+                " (e.g textStyle=\"normal\" can be removed).",
+        CORRECTNESS, PRIORITY, WARNING,
+        Implementation(DefaultLayoutAttributeDetector::class.java, RESOURCE_FILE_SCOPE)
+)
+
+class DefaultLayoutAttributeDetector : LayoutDetector() {
+    override fun getApplicableAttributes() = listOf(ATTR_TEXT_STYLE)
+
+    override fun visitAttribute(context: XmlContext, attribute: Attr) {
+        if ("normal" == attribute.value) {
+            val fix = fix()
+                    .unset(attribute.namespaceURI, attribute.localName)
+                    .name("Remove")
+                    .autoFix()
+                    .build()
+
+            context.report(ISSUE_DEFAULT_LAYOUT_ATTRIBUTE, attribute,
+                    context.getValueLocation(attribute),
+                    "This is the default and hence you don't need to specify it.", fix)
+        }
+    }
+}

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InternalIssueRegistry.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InternalIssueRegistry.kt
@@ -9,7 +9,7 @@ import com.android.tools.lint.detector.api.Issue
 class InternalIssueRegistry : IssueRegistry() {
     override val issues: List<Issue>
         get() = listOf(
-                TODO_ISSUE,
+                ISSUE_TODO,
                 ISSUE_INVALID_IMPORT,
                 ISSUE_NAMING_PATTERN,
                 ISSUE_DEFAULT_LAYOUT_ATTRIBUTE

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InternalIssueRegistry.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InternalIssueRegistry.kt
@@ -8,5 +8,10 @@ import com.android.tools.lint.detector.api.Issue
  */
 class InternalIssueRegistry : IssueRegistry() {
     override val issues: List<Issue>
-        get() = listOf(TODO_ISSUE)
+        get() = listOf(
+                TODO_ISSUE,
+                ISSUE_INVALID_IMPORT,
+                ISSUE_NAMING_PATTERN,
+                ISSUE_DEFAULT_LAYOUT_ATTRIBUTE
+        )
 }

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InternalIssueRegistry.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InternalIssueRegistry.kt
@@ -14,4 +14,6 @@ class InternalIssueRegistry : IssueRegistry() {
                 ISSUE_NAMING_PATTERN,
                 ISSUE_DEFAULT_LAYOUT_ATTRIBUTE
         )
+
+    override val api: Int = com.android.tools.lint.detector.api.CURRENT_API
 }

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InvalidImportDetector.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/InvalidImportDetector.kt
@@ -1,0 +1,42 @@
+package {{ cookiecutter.package_name }}.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.WARNING
+import org.jetbrains.uast.UImportStatement
+import java.util.EnumSet
+
+private const val PRIORITY = 4
+
+val ISSUE_INVALID_IMPORT = Issue.create("InvalidImport",
+        "Flags invalid imports.",
+        "Flags invalid imports. One example is com.foo.bar.R.drawable. Instead just the" +
+                " generated class R should be imported and not R.drawable. Also you should never" +
+                " import anything that's in an internal package.",
+        CORRECTNESS, PRIORITY, WARNING,
+        Implementation(InvalidImportDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES)))
+
+private val disallowedImports = listOf(".R.", "internal.", "internaI.")
+
+class InvalidImportDetector : Detector(), Detector.UastScanner {
+    override fun getApplicableUastTypes() = listOf(UImportStatement::class.java)
+
+    override fun createUastHandler(context: JavaContext) = InvalidImportHandler(context)
+
+    class InvalidImportHandler(private val context: JavaContext) : UElementHandler() {
+        override fun visitImportStatement(node: UImportStatement) {
+            node.importReference?.let { importReference ->
+                if (disallowedImports.any { importReference.asSourceString().contains(it) }) {
+                    context.report(ISSUE_INVALID_IMPORT, node, context.getLocation(importReference),
+                            "Forbidden import")
+                }
+            }
+        }
+    }
+}

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/NamingPatternDetector.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/NamingPatternDetector.kt
@@ -1,0 +1,74 @@
+package {{ cookiecutter.package_name }}.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.WARNING
+import com.intellij.psi.PsiNamedElement
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UEnumConstant
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UVariable
+import org.jetbrains.uast.kotlin.declarations.KotlinUMethod
+import java.util.EnumSet
+
+private const val PRIORITY = 3
+
+val ISSUE_NAMING_PATTERN = Issue.create("NamingPattern",
+        "Names should be well named.",
+        """Sometimes there is more than one reasonable way to convert an English phrase into
+         | camel case, such as when acronyms or unusual constructs like "IPv6" or "iOS" are
+         | present. XML HTTP request becomes XmlHttpRequest.
+         | XMLHTTPRequest would be incorrect.""".trimMargin(),
+        CORRECTNESS, PRIORITY, WARNING,
+        Implementation(NamingPatternDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES)))
+
+class NamingPatternDetector : Detector(), Detector.UastScanner {
+    override fun getApplicableUastTypes() = listOf<Class<out UElement>>(UVariable::class.java,
+            UMethod::class.java, UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext) = NamingPatternHandler(context)
+
+    class NamingPatternHandler(private val context: JavaContext) : UElementHandler() {
+        override fun visitVariable(node: UVariable) {
+            val isConstant = node.isFinal && node.isStatic
+            val isEnumConstant = node is UEnumConstant
+
+            if (!isConstant && !isEnumConstant) {
+                process(node, node)
+            }
+        }
+
+        override fun visitMethod(node: UMethod) {
+            process(node, node)
+        }
+
+        override fun visitClass(node: UClass) {
+            process(node, node)
+        }
+
+        private fun process(scope: UElement, declaration: PsiNamedElement) {
+            val isPropertyBakedMethod = scope is KotlinUMethod
+                    && (scope.sourcePsi as? KtProperty)?.isMember == true
+
+            if (declaration.name?.isDefinedCamelCase() == false && !isPropertyBakedMethod) {
+                context.report(ISSUE_NAMING_PATTERN, scope, context.getNameLocation(scope),
+                        "${declaration.name} is not named in defined camel case.")
+            }
+        }
+    }
+}
+
+private fun String.isDefinedCamelCase(): Boolean {
+    val toCharArray = toCharArray()
+    return toCharArray
+            .mapIndexed { index, current -> current to toCharArray.getOrNull(index + 1) }
+            .none { it.first.isUpperCase() && it.second?.isUpperCase() ?: false }
+}

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/NamingPatternDetector.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/NamingPatternDetector.kt
@@ -55,8 +55,8 @@ class NamingPatternDetector : Detector(), Detector.UastScanner {
         }
 
         private fun process(scope: UElement, declaration: PsiNamedElement) {
-            val isPropertyBakedMethod = scope is KotlinUMethod
-                    && (scope.sourcePsi as? KtProperty)?.isMember == true
+            val isPropertyBakedMethod = scope is KotlinUMethod &&
+                    (scope.sourcePsi as? KtProperty)?.isMember == true
 
             if (declaration.name?.isDefinedCamelCase() == false && !isPropertyBakedMethod) {
                 context.report(ISSUE_NAMING_PATTERN, scope, context.getNameLocation(scope),

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/TodoDetector.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/TodoDetector.kt
@@ -23,15 +23,15 @@ private const val COMMENT = "TODO"
 private val pattern = Pattern.compile("[\\t]*[//].*$COMMENT.*", Pattern.CASE_INSENSITIVE)
 
 val ISSUE_TODO = Issue.create(
-    "UnresolvedTodo",
-    "Unresolved todo",
-    """This check highlights comments indicating that some part of the code is unresolved.
+        "UnresolvedTodo",
+        "Unresolved todo",
+        """This check highlights comments indicating that some part of the code is unresolved.
         Please address and remove all **TODO** comments before ship!
         """.trimIndent(),
-    Category.CORRECTNESS,
-    PRIORITY,
-    Severity.WARNING,
-    Implementation(TodoDetector::class.java, Scope.JAVA_FILE_SCOPE)
+        Category.CORRECTNESS,
+        PRIORITY,
+        Severity.WARNING,
+        Implementation(TodoDetector::class.java, Scope.JAVA_FILE_SCOPE)
 )
 
 /**

--- a/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/TodoDetector.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/main/java/{{ cookiecutter.package_dir }}/lint/TodoDetector.kt
@@ -18,17 +18,18 @@ import org.jetbrains.uast.UElement
 import org.w3c.dom.Document
 import java.util.regex.Pattern
 
+private const val PRIORITY = 6
 private const val COMMENT = "TODO"
 private val pattern = Pattern.compile("[\\t]*[//].*$COMMENT.*", Pattern.CASE_INSENSITIVE)
 
-val TODO_ISSUE = Issue.create(
+val ISSUE_TODO = Issue.create(
     "UnresolvedTodo",
     "Unresolved todo",
     """This check highlights comments indicating that some part of the code is unresolved.
         Please address and remove all **TODO** comments before ship!
         """.trimIndent(),
     Category.CORRECTNESS,
-    6,
+    PRIORITY,
     Severity.WARNING,
     Implementation(TodoDetector::class.java, Scope.JAVA_FILE_SCOPE)
 )
@@ -52,7 +53,7 @@ class TodoDetector : Detector(), UastScanner, GradleScanner, OtherFileScanner, X
             val start = matcher.start()
             val end = matcher.end()
             val location = Location.create(context.file, source, start, end)
-            context.report(TODO_ISSUE, location, "TODO comment found")
+            context.report(ISSUE_TODO, location, "TODO comment found")
         }
     }
 }

--- a/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/DefaultLayoutAttributeTest.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/DefaultLayoutAttributeTest.kt
@@ -1,0 +1,78 @@
+package {{ cookiecutter.package_name }}.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.xml
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class DefaultLayoutAttributeTest {
+    @Test
+    fun testTextStyleNormal() {
+        val xml = xml("res/layout/ids.xml", """
+          <TextView
+              xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:text="Lint will not like this"
+              android:textStyle="normal"/>""").indented()
+
+        val expected = """
+          |res/layout/ids.xml:6: Warning: This is the default and hence you don't need to specify it. [DefaultLayoutAttribute]
+          |    android:textStyle="normal"/>
+          |                       ~~~~~~
+          |0 errors, 1 warnings
+        """.trimMargin()
+
+        lint().files(xml).issues(ISSUE_DEFAULT_LAYOUT_ATTRIBUTE).run().expect(expected)
+    }
+
+    @Test
+    fun testNoAttribute() {
+        val xml = xml("res/layout/ids.xml", """
+          <TextView
+              xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:text="Lint will like this"/>
+              """).indented()
+
+        lint().files(xml).issues(ISSUE_DEFAULT_LAYOUT_ATTRIBUTE).run().expectClean()
+    }
+
+    @Test
+    fun testTextStyleItalic() {
+        val xml = xml("res/layout/ids.xml", """
+          <TextView
+              xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:text="Lint will like this"
+              android:textStyle="italic"/>""").indented()
+
+        lint().files(xml).issues(ISSUE_DEFAULT_LAYOUT_ATTRIBUTE).run().expectClean()
+    }
+
+    // if the DefaultLayoutAttribute is ignored in the tools namespace
+    @Test
+    fun testTextStyleIgnored() {
+        val xml = xml("res/layout/ids.xml", """
+          <TextView
+              xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:textStyle="normal"
+              tools:ignore="DefaultLayoutAttribute"/>""").indented()
+
+        lint().files(xml).issues(ISSUE_DEFAULT_LAYOUT_ATTRIBUTE).run().expectClean()
+    }
+
+    @Test fun shouldNotCrashWithStyle() {
+        lint()
+                .files(xml("res/layout/ids.xml", """
+          <TextView
+              style="?android:attr/borderlessButtonStyle"/>""").indented())
+                .issues(ISSUE_DEFAULT_LAYOUT_ATTRIBUTE)
+                .run()
+                .expectClean()
+    }
+}

--- a/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/InvalidImportTest.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/InvalidImportTest.kt
@@ -1,0 +1,49 @@
+package {{ cookiecutter.package_name }}.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.java
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class InvalidImportTest {
+    @Test fun normalRImport() {
+        val file = java("""
+          package foo;
+          import foo.R;
+          class Example {
+          }""").indented()
+
+        lint().files(file).issues(ISSUE_INVALID_IMPORT).run().expectClean()
+    }
+
+    @Test fun rDrawableImport() {
+        val file = java("""
+          package foo;
+          import foo.R.drawable;
+          class Example {
+          }""").indented()
+
+        val expected = """
+          |src/foo/Example.java:2: Warning: Forbidden import [InvalidImport]
+          |import foo.R.drawable;
+          |       ~~~~~~~~~~~~~~
+          |0 errors, 1 warnings""".trimMargin()
+
+        lint().files(file).issues(ISSUE_INVALID_IMPORT).run().expect(expected)
+    }
+
+    @Test fun internalImport() {
+        val file = java("""
+          package foo;
+          import com.foo.internal.Foo;
+          class Example {
+          }""").indented()
+
+        val expected = """
+          |src/foo/Example.java:2: Warning: Forbidden import [InvalidImport]
+          |import com.foo.internal.Foo;
+          |       ~~~~~~~~~~~~~~~~~~~~
+          |0 errors, 1 warnings""".trimMargin()
+
+        lint().files(file).issues(ISSUE_INVALID_IMPORT).run().expect(expected)
+    }
+}

--- a/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/NamingPatternTest.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/NamingPatternTest.kt
@@ -1,0 +1,127 @@
+package {{ cookiecutter.package_name }}.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.java
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class NamingPatternTest {
+    @Test
+    fun incorrectVariableName() {
+        val file = java("""
+            package foo;
+            class Foo {
+              private void fun() {
+                String iOSVersion;
+              }
+            }""").indented()
+
+        val expected = """
+            |src/foo/Foo.java:4: Warning: iOSVersion is not named in defined camel case. [NamingPattern]
+            |    String iOSVersion;
+            |           ~~~~~~~~~~
+            |0 errors, 1 warnings""".trimMargin()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expect(expected)
+    }
+
+    @Test fun incorrectMethodName() {
+        val file = java("""
+            package foo;
+            class Foo {
+              private void makeHTTPRequest() {
+              }
+            }""").indented()
+
+        val expected = """
+            |src/foo/Foo.java:3: Warning: makeHTTPRequest is not named in defined camel case. [NamingPattern]
+            |  private void makeHTTPRequest() {
+            |               ~~~~~~~~~~~~~~~
+            |0 errors, 1 warnings""".trimMargin()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expect(expected)
+    }
+
+    @Test fun ignoreEnumConstants() {
+        val file = java("""
+            package foo;
+            public enum Enum {
+              FOO
+            }""").indented()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expectClean()
+    }
+
+    @Test fun ignoreInterfaceConstants() {
+        val file = java("""
+            package foo;
+            interface Something {
+              String FOO = "bar";
+            }""").indented()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expectClean()
+    }
+
+    @Test fun correctClassName() {
+        val file = java("""
+            package foo;
+            class XmlHttpRequest {
+            }""").indented()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expectClean()
+    }
+
+    @Test fun incorrectClassName() {
+        val file = java("""
+            package foo;
+            class XMLHTTPRequest {
+            }""").indented()
+
+        val expected = """
+            |src/foo/XMLHTTPRequest.java:2: Warning: XMLHTTPRequest is not named in defined camel case. [NamingPattern]
+            |class XMLHTTPRequest {
+            |      ~~~~~~~~~~~~~~
+            |0 errors, 1 warnings""".trimMargin()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expect(expected)
+    }
+
+    @Test fun kotlinValGetMethodIgnored() {
+        val file = kt("""
+            package foo
+            class Foo {
+              val aTimes = 0
+            }""").indented()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expectClean()
+    }
+
+    @Test fun kotlinValInvalidName() {
+        val file = kt("""
+            package foo
+            class Foo {
+              val ATimes = 0
+            }""").indented()
+
+        val expected = """
+            |src/foo/Foo.kt:3: Warning: ATimes is not named in defined camel case. [NamingPattern]
+            |  val ATimes = 0
+            |      ~~~~~~
+            |0 errors, 1 warnings
+            """.trimMargin()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expect(expected)
+    }
+
+    @Test fun ignoreKotlinCreator() {
+        val file = kt("""
+            package foo
+            class Test {
+              companion object {
+                val CREATOR = Runnable { }
+              }
+            }""").indented()
+
+        lint().files(file).issues(ISSUE_NAMING_PATTERN).run().expectClean()
+    }
+}

--- a/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/TodoLintTest.kt
+++ b/{{ cookiecutter.repo_name }}/lint/src/test/java/{{ cookiecutter.package_dir }}/lint/TodoLintTest.kt
@@ -67,7 +67,6 @@ class TodoLintTest : LintDetectorTest() {
         """.trimIndent()
 
         lint().files(file).run().expect(expected)
-
     }
 
     @Test


### PR DESCRIPTION
- Added Default layout attribute, invalid import, and naming pattern Lint issues

1.  Default Layout Attribute
    - Flags default layout values that are not needed. One for instance is the textStyle="normal" that can be just removed.
2. Invalid Import
    - Flags invalid imports. One example is com.foo.bar.R.drawable. Instead just the generated class R should be imported and not R.drawable. Also you should never import anything that's in an internal package.
3. Naming Pattern
    - Sometimes there is more than one reasonable way to convert an English phrase into camel case, such as when acronyms or unusual constructs like "IPv6" or "iOS" are present. XML HTTP request becomes XmlHttpRequest. XMLHTTPRequest would be incorrect.

[Lifted from vanniktech's lint rules](https://github.com/vanniktech/lint-rules)