### PR TITLE
Added Jacoco to modules

### DIFF
--- a/{{ cookiecutter.repo_name }}/app/build.gradle
+++ b/{{ cookiecutter.repo_name }}/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android.extensions'
+apply from: "$rootDir/gradle/coverage.gradle"
 
 if (isCiBuild) {
     apply from: "${project.rootDir}/gradle/deploy.gradle"
@@ -22,6 +23,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            testCoverageEnabled true
         }
         release {
             minifyEnabled true

--- a/{{ cookiecutter.repo_name }}/cache/build.gradle
+++ b/{{ cookiecutter.repo_name }}/cache/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply from: "$rootDir/gradle/coverage.gradle"
 
 android {
     compileSdkVersion buildConfig.compileSdk
@@ -18,6 +19,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            testCoverageEnabled true
         }
         release {
             minifyEnabled true

--- a/{{ cookiecutter.repo_name }}/data/build.gradle
+++ b/{{ cookiecutter.repo_name }}/data/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply from: "$rootDir/gradle/coverage.gradle"
 
 android {
     compileSdkVersion buildConfig.compileSdk
@@ -17,6 +18,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            testCoverageEnabled true
         }
         release {
             minifyEnabled true

--- a/{{ cookiecutter.repo_name }}/device/build.gradle
+++ b/{{ cookiecutter.repo_name }}/device/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply from: "$rootDir/gradle/coverage.gradle"
 
 android {
     compileSdkVersion buildConfig.compileSdk
@@ -17,6 +18,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            testCoverageEnabled true
         }
         release {
             minifyEnabled true

--- a/{{ cookiecutter.repo_name }}/docs/code_coverage.md
+++ b/{{ cookiecutter.repo_name }}/docs/code_coverage.md
@@ -1,0 +1,11 @@
+# Code Coverage
+
+## Generating a Coverage Report
+A code coverage report can be generated  using the `test<AppVariant>UnitTestCoverage` task (e.g `testDebugUnitTestCoverage`, `testDevelopDebugUnitTestCoverage`).<br/>
+The generated report HTML can be found in each module's corresponding /build/reports/jacoco/ directory.
+
+## Coverage Verification
+
+Code coverage can be verified using the `test<AppVariant>UnitTestCoverageVerification` task.
+The minimum code-coverage percentage is 60% by default.
+This can be changed by changing the value of `MINIMUM_COVERAGE` in `coverage.gradle`

--- a/{{ cookiecutter.repo_name }}/gradle/coverage.gradle
+++ b/{{ cookiecutter.repo_name }}/gradle/coverage.gradle
@@ -7,18 +7,15 @@ def fileFilter = [
 def mainSrc = "$project.projectDir/src/main/kotlin"
 def configDir = "${project.rootDir}/config"
 def reportDir = "${project.buildDir}/reports"
-def debugTree
 jacoco.toolVersion = versions.jacoco
+
+def MINIMUM_COVERAGE = 0.60     // The minimum code-coverage percentage
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
 }
 
 project.afterEvaluate {
-    // Grab all build types and product flavors
-    def buildTypes = android.buildTypes.collect { type ->
-        type.name
-    }
     def productFlavors = android.productFlavors.collect { flavor ->
         flavor.name
     }
@@ -29,50 +26,49 @@ project.afterEvaluate {
     productFlavors.each {
 
         productFlavorName ->
-            //iterate over build types like debug,release,prod etc.
-            buildTypes.each {
+            def sourceName, sourcePath
+            def buildTypeName = 'debug'
 
-                buildTypeName ->
-                    //sourceName — e.g. freeDebug ,sourcePath — e.g. free/debug
-                    def sourceName, sourcePath
-                    if (!productFlavorName) {
-                        sourceName = sourcePath = "${buildTypeName}"
-                        debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: fileFilter)
-                    } else {
-                        sourceName = "${productFlavorName}${buildTypeName.capitalize()}"
-                        sourcePath = "${productFlavorName}/${buildTypeName}"
-                        debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/${sourceName}", excludes: fileFilter)
-                    }
-
-                    def testTaskName = "test${sourceName.capitalize()}UnitTest"
-                    def coverageReportTaskName = "create${sourceName.capitalize()}CoverageReport"
-                    task "${testTaskName}Coverage"(type: JacocoReport, dependsOn: ["${testTaskName}", "${coverageReportTaskName}"]) {
-                        group = 'Reporting'
-                        reports {
-                            xml.enabled = true
-                            html.enabled = true
-                        }
-
-                        sourceDirectories = files([mainSrc])
-                        classDirectories = files([debugTree])
-                        executionData = fileTree(dir: project.buildDir, includes: [
-                                "jacoco/${testTaskName}.exec", "outputs/code_coverage/${sourceName}AndroidTest/connected/*coverage.ec"
-                        ])
-                    }
-
-                    task "${testTaskName}CoverageVerification"(type: JacocoCoverageVerification, dependsOn: "jacoco${testTaskName}Coverage") {
-                        sourceDirectories = files([mainSrc])
-                        classDirectories = files([debugTree])
-                        executionData = files("${buildDir}/jacoco/${testTaskName}.exec")
-                        violationRules {
-                            failOnViolation = true
-                            rule {
-                                limit {
-                                    minimum = 1
-                                }
-                            }
-                        }
-                    }
+            if (!productFlavorName) {
+                sourceName = sourcePath = "${buildTypeName}"
+            } else {
+                sourceName = "${productFlavorName}${buildTypeName.capitalize()}"
+                sourcePath = "${productFlavorName}/${buildTypeName}"
             }
+
+            def debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/${sourceName}", excludes: fileFilter)
+            def testTaskName = "test${sourceName.capitalize()}UnitTest"
+            def coverageReportTaskName = "create${sourceName.capitalize()}CoverageReport"
+            task "${testTaskName}Coverage"(type: JacocoReport, dependsOn: ["${testTaskName}", "${coverageReportTaskName}"]) {
+                group = 'Reporting'
+                reports {
+                    xml.enabled = true
+                    html.enabled = true
+                }
+
+                sourceDirectories = files([mainSrc])
+                classDirectories = files([debugTree])
+                executionData = fileTree(dir: project.buildDir, includes: [
+                        "jacoco/${testTaskName}.exec", "outputs/code_coverage/${sourceName}AndroidTest/connected/*coverage.ec"
+                ])
+            }
+
+            task "${testTaskName}CoverageVerification"(type: JacocoCoverageVerification, dependsOn: "${testTaskName}Coverage") {
+                group = 'Verification'
+                sourceDirectories = files([mainSrc])
+                classDirectories = files([debugTree])
+                executionData = fileTree(dir: project.buildDir, includes: [
+                        "jacoco/${testTaskName}.exec", "outputs/code_coverage/${sourceName}AndroidTest/connected/*coverage.ec"
+                ])
+                violationRules {
+                    failOnViolation = true
+                    rule {
+                        limit {
+                            minimum = MINIMUM_COVERAGE
+                        }
+                    }
+                }
+            }
+
     }
 }

--- a/{{ cookiecutter.repo_name }}/gradle/coverage.gradle
+++ b/{{ cookiecutter.repo_name }}/gradle/coverage.gradle
@@ -1,0 +1,78 @@
+apply from: "$rootDir/gradle/dependencies.gradle"
+apply plugin: 'jacoco'
+
+def fileFilter = [
+        '**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*', '**/*$[0-9].*',
+]
+def mainSrc = "$project.projectDir/src/main/kotlin"
+def configDir = "${project.rootDir}/config"
+def reportDir = "${project.buildDir}/reports"
+def debugTree
+jacoco.toolVersion = versions.jacoco
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+project.afterEvaluate {
+    // Grab all build types and product flavors
+    def buildTypes = android.buildTypes.collect { type ->
+        type.name
+    }
+    def productFlavors = android.productFlavors.collect { flavor ->
+        flavor.name
+    }
+    if (!productFlavors) productFlavors.add('')
+
+    //iterate over the flavors
+
+    productFlavors.each {
+
+        productFlavorName ->
+            //iterate over build types like debug,release,prod etc.
+            buildTypes.each {
+
+                buildTypeName ->
+                    //sourceName — e.g. freeDebug ,sourcePath — e.g. free/debug
+                    def sourceName, sourcePath
+                    if (!productFlavorName) {
+                        sourceName = sourcePath = "${buildTypeName}"
+                        debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: fileFilter)
+                    } else {
+                        sourceName = "${productFlavorName}${buildTypeName.capitalize()}"
+                        sourcePath = "${productFlavorName}/${buildTypeName}"
+                        debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/${sourceName}", excludes: fileFilter)
+                    }
+
+                    def testTaskName = "test${sourceName.capitalize()}UnitTest"
+                    def coverageReportTaskName = "create${sourceName.capitalize()}CoverageReport"
+                    task "${testTaskName}Coverage"(type: JacocoReport, dependsOn: ["${testTaskName}", "${coverageReportTaskName}"]) {
+                        group = 'Reporting'
+                        reports {
+                            xml.enabled = true
+                            html.enabled = true
+                        }
+
+                        sourceDirectories = files([mainSrc])
+                        classDirectories = files([debugTree])
+                        executionData = fileTree(dir: project.buildDir, includes: [
+                                "jacoco/${testTaskName}.exec", "outputs/code_coverage/${sourceName}AndroidTest/connected/*coverage.ec"
+                        ])
+                    }
+
+                    task "${testTaskName}CoverageVerification"(type: JacocoCoverageVerification, dependsOn: "jacoco${testTaskName}Coverage") {
+                        sourceDirectories = files([mainSrc])
+                        classDirectories = files([debugTree])
+                        executionData = files("${buildDir}/jacoco/${testTaskName}.exec")
+                        violationRules {
+                            failOnViolation = true
+                            rule {
+                                limit {
+                                    minimum = 1
+                                }
+                            }
+                        }
+                    }
+            }
+    }
+}

--- a/{{ cookiecutter.repo_name }}/gradle/dependencies.gradle
+++ b/{{ cookiecutter.repo_name }}/gradle/dependencies.gradle
@@ -29,6 +29,7 @@ versions.kotshi         = '1.0.5'
 versions.ktlint         = '0.29.0'
 versions.mockito        = '2.22.0'
 versions.lint           = '26.2.1' // Gradle plugin version + 23
+versions.jacoco         = '0.8.2'
 ext.versions            = versions
 
 ext.libs = [
@@ -135,5 +136,6 @@ ext.libs = [
                 'android' : "org.mockito:mockito-android:${versions.mockito}"
         ],
         'assertj': "org.assertj:assertj-core:3.11.1",
-        'dexmaker': "com.linkedin.dexmaker:dexmaker-mockito:2.19.1"
+        'dexmaker': "com.linkedin.dexmaker:dexmaker-mockito:2.19.1",
+        'jacoco': "org.jacoco:org.jacoco.core:$versions.jacoco"
 ]

--- a/{{ cookiecutter.repo_name }}/remote/build.gradle
+++ b/{{ cookiecutter.repo_name }}/remote/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply from: "$rootDir/gradle/coverage.gradle"
 
 android {
     compileSdkVersion buildConfig.compileSdk
@@ -17,6 +18,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            testCoverageEnabled true
         }
         release {
             minifyEnabled true


### PR DESCRIPTION
Added test coverage through Jacoco. Supports multiple flavors.
Run the `test<AppVariant>UnitTestCoverage` task to generate a report. The report will be found in the associated module's /build/reports/jacoco directory.